### PR TITLE
Fix interrupt register saving and system call test

### DIFF
--- a/apps/test.c
+++ b/apps/test.c
@@ -10,7 +10,7 @@ static inline long syscall(uint64_t number, uint64_t arg1, uint64_t arg2, uint64
     __asm__ volatile(
         "int $0x80"
         : "=a"(ret)
-        : "a"(number), "b"(arg1), "c"(arg2), "d"(arg3)
+        : "a"(number), "D"(arg1), "S"(arg2), "d"(arg3)
         : "memory");
     return ret;
 }

--- a/kernel/src/sys/intr.S
+++ b/kernel/src/sys/intr.S
@@ -2,13 +2,13 @@
 .extern real_handlers
 
 isr_handler_stub:
+    pushq %rax
+    pushq %rbx
+    pushq %rcx
+    pushq %rdx
+    pushq %rbp
     pushq %rdi
     pushq %rsi
-    pushq %rbp
-    pushq %rdx
-    pushq %rcx
-    pushq %rbx
-    pushq %rax
     pushq %r8
     pushq %r9
     pushq %r10
@@ -50,13 +50,13 @@ isr_handler_stub:
     popq %r10
     popq %r9
     popq %r8
-    popq %rax
-    popq %rbx
-    popq %rcx
-    popq %rdx
-    popq %rbp
     popq %rsi
     popq %rdi
+    popq %rbp
+    popq %rdx
+    popq %rcx
+    popq %rbx
+    popq %rax
     addq $16, %rsp
 
     iretq

--- a/kernel/src/sys/intr.h
+++ b/kernel/src/sys/intr.h
@@ -10,8 +10,7 @@ struct __attribute__((packed)) register_ctx
 {
     uint64_t es, ds;
     uint64_t cr4, cr3, cr2, cr0;
-    uint64_t r15, r14, r13, r12, r11, r10, r9, r8, rax, rbx, rcx, rdx, rsi, rdi;
-    uint64_t rbp;
+    uint64_t r15, r14, r13, r12, r11, r10, r9, r8, rsi, rdi, rbp, rdx, rcx, rbx, rax;
     uint64_t vector, err;
     uint64_t rip, cs, rflags, rsp, ss;
 };


### PR DESCRIPTION
The register saving in interrupt was out of order and inconsistent with the context struct. This has been resolved now so it is a reasonable order and matches the context struct.

The system call test was used `rbx`, `rcx`, and `rdx` for arguments, when it should have been using `rdi`, `rsi`, and `rdx`.